### PR TITLE
Add simple HTML validation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Tipsy Coder Website
+
+This repository contains the source for the Tipsy Coder static website.
+
+## Running Tests
+
+A simple test script is provided under the `tests/` directory. The script
+parses `index.html` for basic HTML issues and checks that any image URLs are
+reachable.
+
+To run the test, execute:
+
+```bash
+python tests/test_index.py
+```
+
+The script will exit with a non-zero status if it detects a problem.

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,83 @@
+import sys
+from html.parser import HTMLParser
+from urllib.request import urlopen, Request
+from urllib.error import URLError, HTTPError
+
+class SimpleHTMLValidator(HTMLParser):
+    VOID_TAGS = {
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img',
+        'input', 'link', 'meta', 'param', 'source', 'track', 'wbr'
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.stack = []
+        self.errors = []
+        self.images = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'img':
+            for (attr, value) in attrs:
+                if attr == 'src':
+                    self.images.append(value)
+        if tag not in self.VOID_TAGS:
+            self.stack.append(tag)
+
+    def handle_endtag(self, tag):
+        if tag in self.VOID_TAGS:
+            return
+        if not self.stack:
+            self.errors.append(f"Unexpected closing tag </{tag}>")
+            return
+        last = self.stack.pop()
+        if last != tag:
+            self.errors.append(f"Mismatched closing tag </{tag}> for <{last}>")
+
+    def close(self):
+        super().close()
+        if self.stack:
+            for tag in self.stack:
+                self.errors.append(f"Unclosed tag <{tag}>")
+
+
+def validate_html(path='index.html'):
+    with open(path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    parser = SimpleHTMLValidator()
+    parser.feed(content)
+    parser.close()
+    return parser
+
+
+def check_image_urls(urls):
+    for url in urls:
+        try:
+            req = Request(url, method='HEAD')
+            with urlopen(req) as resp:
+                status = resp.status
+            if status >= 400:
+                print(f"Image URL {url} returned status {status}")
+                return False
+        except (URLError, HTTPError) as e:
+            print(f"Failed to reach image URL {url}: {e}")
+            return False
+    return True
+
+
+def main():
+    parser = validate_html()
+    if parser.errors:
+        print('HTML validation errors:')
+        for err in parser.errors:
+            print(' -', err)
+        sys.exit(1)
+    if not parser.images:
+        print('No image tags found to check.')
+    else:
+        if not check_image_urls(parser.images):
+            sys.exit(1)
+    print('All checks passed.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add a Python test to ensure basic HTML validity and image URL availability
- document how to run the test

## Testing
- `python tests/test_index.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684fade3ccd88327a6045a75ef4c6834